### PR TITLE
Read embedding config from YAML

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ QDRANT_COLLECTION=documents
 
 # OpenAI
 OPENAI_API_KEY=
+EMBEDDING_API_URL=
 
 # Poll intervals (seconds)
 INGEST_INTERVAL=30

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project provides a set of microservices for ingesting text, generating embe
 
 ## Quick start
 1. Copy `.env.example` to `.env` and adjust credentials.
+   Set `EMBEDDING_API_URL` when using an external embedding provider.
 2. Build and start the stack:
 
 ```bash

--- a/config/embedding.yaml
+++ b/config/embedding.yaml
@@ -1,0 +1,20 @@
+input:
+  type: local
+  path: /path/to/data
+  credentials: null
+output:
+  type: qdrant
+  destination: http://localhost:6333
+  credentials: null
+format_in: txt
+format_out: json
+processing:
+  model: ada
+  provider: local
+  api_url: null
+  distance: cosine
+  dimension: 1536
+  chunking:
+    strategy: sentence
+    size: 500
+  interval: 60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - QDRANT_HOST=${QDRANT_HOST}
       - QDRANT_PORT=${QDRANT_PORT}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - EMBEDDING_API_URL=${EMBEDDING_API_URL}
       - EMBEDDING_INTERVAL=${EMBEDDING_INTERVAL}
     depends_on:
       - rabbitmq

--- a/microservices/embedding_service/README.md
+++ b/microservices/embedding_service/README.md
@@ -1,1 +1,37 @@
-# microservices/embedding_service/ microservice
+# Embedding Service
+
+This service generates embeddings for documents.
+
+## Configuration
+
+Configuration parameters are read from `config/embedding.yaml` located in the
+repository root. You can override the path with the `EMBEDDING_CONFIG`
+environment variable.
+
+The file defines the following fields:
+
+- **input**: information about the source of documents.
+  - `type`: e.g. `local` or `http`.
+  - `path`/`endpoint`: location of the data.
+  - `credentials`: authentication data if needed.
+- **output**: where generated embeddings are stored.
+  - `type`: storage backend such as `qdrant`.
+  - `destination`: host or file path.
+  - `credentials`: authentication data if required.
+- **format_in**: format of the incoming documents (`txt`, `pdf`, ...).
+- **format_out**: format for the generated embedding payload.
+- **processing**: embedding parameters.
+  - `model`: model name, default `ada`.
+  - `provider`: `local` to run a bundled model or `openai` for an external API.
+    When using an external provider, credentials are taken from the `.env` file
+    (`OPENAI_API_KEY`) and the endpoint can be specified via the `EMBEDDING_API_URL`
+    environment variable.
+  - `api_url`: optional API endpoint when using an external provider.
+  - `distance`: distance metric used.
+  - `dimension`: vector dimension.
+  - `chunking`: strategy details for splitting documents.
+    - `strategy`: chunking method.
+    - `size`: maximum chunk size.
+  - `interval`: number of seconds between processing cycles.
+
+An example configuration is provided in `config/embedding.yaml`.

--- a/microservices/embedding_service/app.py
+++ b/microservices/embedding_service/app.py
@@ -1,13 +1,47 @@
 import os
+from pathlib import Path
 import time
 
-INTERVAL = int(os.getenv('EMBEDDING_INTERVAL', '60'))
+import yaml
+
+# Default configuration file location two directories above this file
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / 'config' / 'embedding.yaml'
+
+
+def load_config(path: Path) -> dict:
+    """Load YAML configuration from *path*.
+
+    Parameters
+    ----------
+    path: Path
+        Path to the YAML configuration file.
+    """
+    with open(path, 'r', encoding='utf-8') as fh:
+        return yaml.safe_load(fh)
 
 
 def main():
+    config_path = Path(os.getenv('EMBEDDING_CONFIG', DEFAULT_CONFIG_PATH))
+    config = load_config(config_path)
+
+    # How often the service runs
+    interval = config.get('processing', {}).get('interval', 60)
+    model = config.get('processing', {}).get('model')
+    provider = config.get('processing', {}).get('provider', 'local')
+    api_url = config.get('processing', {}).get('api_url') or os.getenv('EMBEDDING_API_URL')
+    distance = config.get('processing', {}).get('distance')
+
+    if provider != 'local':
+        api_key = os.getenv('OPENAI_API_KEY')
+        if not api_key:
+            raise RuntimeError('OPENAI_API_KEY must be set for external providers')
+
     while True:
         print('Embedding service running...')
-        time.sleep(INTERVAL)
+        print(f"Model: {model}, provider: {provider}, distance: {distance}")
+        if api_url:
+            print(f"API URL: {api_url}")
+        time.sleep(interval)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ qdrant-client
 pika
 sentence-transformers
 torch
+PyYAML


### PR DESCRIPTION
## Summary
- add example configuration in `config/embedding.yaml`
- load YAML configuration in embedding service
- document new configuration
- include PyYAML dependency
- support selecting provider via config and `.env`

## Testing
- `python -m py_compile microservices/embedding_service/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851b0bf7a588332a3edb2562fdd24ff