### PR TITLE
Update README docs for YAML and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,25 @@ make up
 
 Visit the RabbitMQ management UI at `http://localhost:15672` and Qdrant at `http://localhost:6333`.
 
+## Configuración YAML
+El archivo `docker-compose.yml` describe cómo se orquestan los microservicios y las variables de entorno que utilizan. Cada sección puede personalizarse para apuntar a diferentes orígenes de datos o colecciones de Qdrant.
+
+Ejemplo de fragmento:
+
+```yaml
+embedding:
+  build: ./microservices/embedding_service
+  environment:
+    - RABBITMQ_HOST=${RABBITMQ_HOST}
+    - QDRANT_HOST=${QDRANT_HOST}
+    - OPENAI_API_KEY=${OPENAI_API_KEY}
+```
+
+Tras editar `.env` y el YAML, la pila completa puede iniciarse con:
+
+```bash
+docker compose up -d
+```
+
 ## Development
 Each service has a simple `app.py` that polls for work. Polling intervals and connection settings are taken from environment variables defined in `.env`.

--- a/microservices/embedding_service/README.md
+++ b/microservices/embedding_service/README.md
@@ -1,1 +1,31 @@
-# microservices/embedding_service/ microservice
+# Embedding Service
+
+Genera vectores usando OpenAI a partir de los mensajes recibidos y los envía a Qdrant.
+
+## Campos relevantes del YAML
+```yaml
+embedding:
+  build: ./microservices/embedding_service
+  environment:
+    - RABBITMQ_HOST=${RABBITMQ_HOST}
+    - RABBITMQ_PORT=${RABBITMQ_PORT}
+    - QDRANT_HOST=${QDRANT_HOST}
+    - QDRANT_PORT=${QDRANT_PORT}
+    - OPENAI_API_KEY=${OPENAI_API_KEY}
+    - EMBEDDING_INTERVAL=${EMBEDDING_INTERVAL}
+```
+- **RABBITMQ_HOST/PORT**: origen de mensajes con texto.
+- **QDRANT_HOST/PORT**: base de vectores de destino.
+- **OPENAI_API_KEY**: credencial para generar embeddings.
+- **EMBEDDING_INTERVAL**: pausa entre iteraciones.
+
+## Ejecución independiente
+1. Instala dependencias:
+   ```bash
+   pip install -r ../../requirements.txt
+   ```
+2. Exporta las variables indicadas.
+3. Ejecuta:
+   ```bash
+   python app.py
+   ```

--- a/microservices/ingest_service/README.md
+++ b/microservices/ingest_service/README.md
@@ -1,1 +1,26 @@
-# microservices/ingest_service/ microservice
+# Ingest Service
+
+Obtiene y normaliza texto para publicarlo en RabbitMQ.
+
+## Campos relevantes del YAML
+```yaml
+ingest:
+  build: ./microservices/ingest_service
+  environment:
+    - RABBITMQ_HOST=${RABBITMQ_HOST}
+    - RABBITMQ_PORT=${RABBITMQ_PORT}
+    - INGEST_INTERVAL=${INGEST_INTERVAL}
+```
+- **RABBITMQ_HOST/PORT**: cola de mensajes de salida.
+- **INGEST_INTERVAL**: intervalo de consulta.
+
+## Ejecución independiente
+1. Instala las dependencias:
+   ```bash
+   pip install -r ../../requirements.txt
+   ```
+2. Exporta las variables de entorno anteriores.
+3. Ejecuta:
+   ```bash
+   python app.py
+   ```

--- a/microservices/query_service/README.md
+++ b/microservices/query_service/README.md
@@ -1,1 +1,28 @@
-# microservices/query_service/ microservice
+# Query Service
+
+Proporciona una API básica para consultar los vectores almacenados en Qdrant (en desarrollo).
+
+## Campos relevantes del YAML
+```yaml
+query:
+  build: ./microservices/query_service
+  ports:
+    - "8000:8000"
+  environment:
+    - QDRANT_HOST=${QDRANT_HOST}
+    - QDRANT_PORT=${QDRANT_PORT}
+    - QUERY_INTERVAL=${QUERY_INTERVAL}
+```
+- **QDRANT_HOST/PORT**: origen de la información vectorial.
+- **QUERY_INTERVAL**: intervalo de trabajo del servicio.
+
+## Ejecución independiente
+1. Instala dependencias:
+   ```bash
+   pip install -r ../../requirements.txt
+   ```
+2. Exporta las variables mencionadas.
+3. Ejecuta:
+   ```bash
+   python app.py
+   ```

--- a/microservices/storage_service/README.md
+++ b/microservices/storage_service/README.md
@@ -1,1 +1,30 @@
-# microservices/storage_service/ microservice
+# Storage Service
+
+Recibe embeddings y los almacena en la colección de Qdrant.
+
+## Campos relevantes del YAML
+```yaml
+storage:
+  build: ./microservices/storage_service
+  environment:
+    - RABBITMQ_HOST=${RABBITMQ_HOST}
+    - RABBITMQ_PORT=${RABBITMQ_PORT}
+    - QDRANT_HOST=${QDRANT_HOST}
+    - QDRANT_PORT=${QDRANT_PORT}
+    - QDRANT_API_KEY=${QDRANT_API_KEY}
+    - STORAGE_INTERVAL=${STORAGE_INTERVAL}
+```
+- **RABBITMQ_HOST/PORT**: origen de mensajes con embeddings.
+- **QDRANT_HOST/PORT** y **QDRANT_API_KEY**: destino de almacenamiento.
+- **STORAGE_INTERVAL**: pausa de trabajo.
+
+## Ejecución independiente
+1. Instala dependencias:
+   ```bash
+   pip install -r ../../requirements.txt
+   ```
+2. Exporta las variables mencionadas.
+3. Ejecuta:
+   ```bash
+   python app.py
+   ```


### PR DESCRIPTION
## Summary
- add YAML configuration section with example usage
- document service details, YAML fields and standalone steps in each microservice README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b26f47848332b1b5780856c906a9